### PR TITLE
feat: create without returning err

### DIFF
--- a/internal/repositories/users/users.go
+++ b/internal/repositories/users/users.go
@@ -34,17 +34,15 @@ func New(db *mongo.Database) Repository {
 func (h *userRepository) Create(ctx context.Context, user *domain.User) (*domain.User, error) {
 	filter := bson.M{"email": user.Email, "cpf": user.CPF}
 	err := user.Read(ctx, h.db, USER_COLLECTION, filter, user)
-	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			err = user.Create(ctx, h.db, USER_COLLECTION, user)
-			if err != nil {
-				return nil, exceptions.New(exceptions.ErrDatabaseFailure, err)
-			}
-			return user, nil
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		err = user.Create(ctx, h.db, USER_COLLECTION, user)
+		if err != nil {
+			return nil, exceptions.New(exceptions.ErrDatabaseFailure, err)
 		}
+		return user, nil
 	}
 
-	return nil, exceptions.New(exceptions.ErrUserAlreadyExists, err)
+	return user, nil
 }
 
 func (h *userRepository) Get(ctx context.Context, id primitive.ObjectID) (*domain.User, error) {


### PR DESCRIPTION
This pull request includes a critical bug fix in the `Create` method of the `userRepository` class in the `internal/repositories/users/users.go` file. The fix ensures that the method correctly handles the scenario where a user already exists, preventing the method from returning an error unnecessarily.

Bug fix:

* [`internal/repositories/users/users.go`](diffhunk://#diff-5c8eede2a633bbeb00b5239119e058659ecc6682a478f7fbdf777568b6801402L37-R45): Corrected the logic in the `Create` method to ensure that it returns the user object when the user already exists, instead of returning an error.