### PR TITLE
feat: remove cpf dot validation

### DIFF
--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -46,8 +46,8 @@ func (u *UserRequest) Validate() error {
 	if err != nil || !match {
 		return exceptions.New(exceptions.ErrInvalidEmail, nil)
 	}
-	match, err = regexp.MatchString("^[0-9]{3}.[0-9]{3}.[0-9]{3}-[0-9]{2}$", u.CPF)
-	if err != nil || !match {
+
+	if len(u.CPF) != 11 {
 		return exceptions.New(exceptions.ErrInvalidCPF, nil)
 	}
 


### PR DESCRIPTION
This pull request includes a small but important change to the `Validate` method in the `internal/domain/domain.go` file. The change simplifies the CPF validation logic by checking the length of the CPF instead of using a regular expression.

* [`internal/domain/domain.go`](diffhunk://#diff-31f0dac3ead01690242c1b3b77aecaedbe6e597da094216d65f95da3d093cc4aL49-R50): Modified the `Validate` method in the `UserRequest` struct to check the length of the CPF instead of using a regular expression for validation.