### PR TITLE
feat: create user returning with categories

### DIFF
--- a/internal/repositories/users/users.go
+++ b/internal/repositories/users/users.go
@@ -36,7 +36,12 @@ func New(db *mongo.Database) Repository {
 }
 
 func (h *userRepository) Create(ctx context.Context, user *domain.User) (*domain.User, error) {
-	filter := bson.M{"email": user.Email, "cpf": user.CPF}
+	filter := bson.M{
+		"$or": []bson.M{
+			{"email": user.Email},
+			{"cpf": user.CPF},
+		},
+	}
 	err := user.Read(ctx, h.db, USER_COLLECTION, filter, user)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		err = user.Create(ctx, h.db, USER_COLLECTION, user)


### PR DESCRIPTION
This pull request includes several important changes to the user repository and service layers to improve the handling of user creation and retrieval. The changes primarily focus on modifying the user creation logic to include user categories and updating the corresponding service interface and implementation.

### Repository Layer Changes:
* [`internal/repositories/users/users.go`](diffhunk://#diff-5c8eede2a633bbeb00b5239119e058659ecc6682a478f7fbdf777568b6801402L39-R44): Refactored the `Create` method to use an `$or` filter for checking existing users by email or CPF. This change ensures that a user is uniquely identified by either their email or CPF.

### Service Layer Changes:
* [`internal/services/users/users.go`](diffhunk://#diff-f3ad49aa6a3dee2df69d80093aed479431d54833f902e34c9b5aaa4cb6f691f2L13-R13): Updated the `Create` method in the `Service` interface to return a `UserWithCategories` object instead of a `User` object. This change reflects the inclusion of user categories in the creation process.
* `internal/services/users/users.go`: Modified the `Create` method implementation to:
  - Validate the user request.
  - Convert the request to a user object.
  - Call the repository's `Create` method.
  - Aggregate user categories and return a `UserWithCategories` object. This ensures that the created user's categories are fetched and included in the response.